### PR TITLE
Use local action in PR/branch CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test tag filtering
     steps:
+      - uses: actions/checkout@v3
       - name: Find matching tags asc
         id: find_matching_tags_asc
         uses: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: Find matching tags asc
         id: find_matching_tags_asc
-        uses: Rochet2/find-matching-tags-ghapi@main
+        uses: ./
         with:
           regex: ^TEST\-.*
           sort: asc
@@ -23,7 +23,7 @@ jobs:
           actual: ${{ steps.find_matching_tags_asc.outputs.tags }}
       - name: Find matching tags desc
         id: find_matching_tags_desc
-        uses: Rochet2/find-matching-tags-ghapi@main
+        uses: ./
         with:
           regex: ^TEST\-.*
           sort: desc


### PR DESCRIPTION
The CI uses the latest code from main branch when tests run.
As a result, the CI is unable to test changes made in branches or pull requests.

This PR changes the CI to use the local code for the action instead of pulling code from the github repository main branch.